### PR TITLE
Use supported parameters

### DIFF
--- a/resources/clusterbuildstrategy/ansible-builder-clusterbuildstrategy.yml
+++ b/resources/clusterbuildstrategy/ansible-builder-clusterbuildstrategy.yml
@@ -15,13 +15,13 @@ spec:
           #echo $(id -u):1100000000:65536 >> /etc/subgid
 
           # Change into directory containing EE
-          cd /workspace/source/$(build.source.contextDir)
+          cd $(params.shp-source-context)
 
           # Create Ansible Build Context
           /usr/bin/ansible-builder create -c $HOME/context
 
           # Build the EE
-          /usr/bin/buildah --storage-driver=vfs build -t $(build.output.image) $HOME/context
+          /usr/bin/buildah --storage-driver=vfs build -t $(params.shp-output-image) $HOME/context
       command:
         - /bin/bash
       image: "quay.io/ablock/ansible-builder-nested:latest"
@@ -36,12 +36,12 @@ spec:
       volumeMounts:
         - mountPath: /home/builder/.local/share/containers/storage
           name: ansible-builder-images
-      workingDir: /workspace/source
     - args:
         - --storage-driver=vfs
         - push
+        - --digestfile=$(results.shp-image-digest.path)
         - "--tls-verify=false"
-        - $(build.output.image)
+        - $(params.shp-output-image)
       command:
         - /usr/bin/buildah
       image: "quay.io/ablock/ansible-builder-nested:latest"
@@ -56,3 +56,6 @@ spec:
       volumeMounts:
         - mountPath: /home/builder/.local/share/containers/storage
           name: ansible-builder-images
+  volumes:
+    - name: ansible-builder-images
+      emptyDir: {}


### PR DESCRIPTION
Thanks for that blog post, https://www.ansible.com/blog/creating-automation-execution-environments-using-ansible-builder-and-shipwright.

I am changing your build strategy to use the parameters that are supported and documented in https://shipwright.io/docs/build/buildstrategies/#system-parameters. We had not updated our documentation on our website for some time until June, so maybe you retrieved the old things from there.

I also added the `--digestfile=$(results.shp-image-digest.path)` argument to the push operation (this makes the digest available in the BuildRun status). This is only available in recent buildah versions I think. Given I cannot pull `registry.redhat.io/ansible-automation-platform-21/ansible-builder-rhel8:1.0`, I cannot verify which buildah version is getting installed there. So please do not blindly merge this, but verify that this parameter works.

Beside that, since Shipwright v0.10, we do not support implicit emptyDir volumes anymore. I added the explicit one.

What you could do in addition is to merge the two steps into one. I personally don't see too much value in having the push separate, but that choice is up to you.

Also, I have not fixed the code injection possibilities in your strategy, see https://shipwright.io/docs/build/buildstrategies/#securely-referencing-string-parameters.